### PR TITLE
feat: add Wizard auto-completion and seed data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Repository: https://github.com/erseco/alpine-facturascripts
 - **Compact** Docker image size (~30MB)
 - **Uses PHP 8.4 FPM** for better performance, lower CPU usage & memory footprint
 - **Unattended Installation** - skip the web installer with environment variables
+- **Wizard Auto-Completion** - fully configures company, models, and accounting plan on first boot
+- **Seed Data Loading** - pre-populate suppliers, products, etc. from a JSON file via `FS_SEED_FILE`
 - **Automatic Plugin Installation** - install plugins on first startup via `FS_PLUGINS`
 - **Automatic Cron Tasks** - hourly scheduled tasks via dcron (can be disabled)
 - **Configurable** via environment variables (see Configuration section)
@@ -199,6 +201,12 @@ You can configure the container using the following environment variables in you
 | `FS_DISABLE_RM_PLUGINS` | Disable plugin removal                      | `false`                    |
 | `FS_DISABLE_ADD_PLUGINS`| Disable plugin installation                 | `false`                    |
 | `FS_DISABLE_RM_USERS`   | Disable user removal                        | `false`                    |
+| `FS_CODPAIS`            | Country code (ESP, DEU, FRA, etc.)          | `ESP`                      |
+| `FS_COMPANY_NAME`       | Company name for auto-setup                 | `Mi Empresa`               |
+| `FS_COMPANY_CIF`        | Company tax ID (CIF/NIF)                    | `""`                       |
+| `FS_COMPANY_REGIMENIVA` | VAT regime (General, Simplified, etc.)      | `General`                  |
+| `FS_LOAD_ACCOUNTING_PLAN` | Load default accounting plan (true/false) | `true`                     |
+| `FS_SEED_FILE`          | Path to JSON seed data file                 | `""`                       |
 | `FS_PLUGINS`            | Space-separated list of plugins to install  | `""`                       |
 
 **Note about `FS_PLUGINS`:** Supports plugin names, download IDs, or full URLs. Plugins are installed only on first startup. See "Automatic Plugin Installation" section for details.
@@ -355,7 +363,125 @@ docker compose exec facturascripts rm /var/www/html/Plugins/.plugins_installed
 docker compose restart facturascripts
 ```
 
-### 4. Scheduled Tasks (Cron)
+### 4. Company Setup (Wizard Auto-Completion)
+
+When `FS_INITIAL_USER` is set, the container now automatically completes the FacturaScripts installation wizard, so you never see the Wizard page in the browser. This sets up the company, country defaults, all database tables, and the default accounting plan.
+
+#### Company Configuration Variables
+
+| Variable Name              | Description                        | Default       |
+|----------------------------|------------------------------------|---------------|
+| `FS_CODPAIS`               | Country code (ESP, DEU, FRA, etc.) | `ESP`         |
+| `FS_COMPANY_NAME`          | Company name                       | `Mi Empresa`  |
+| `FS_COMPANY_CIF`           | Company tax ID (CIF/NIF)           | `""`          |
+| `FS_COMPANY_REGIMENIVA`    | VAT regime (General, Simplified)   | `General`     |
+| `FS_LOAD_ACCOUNTING_PLAN`  | Load default accounting plan       | `true`        |
+
+#### Example
+
+```yaml
+environment:
+  FS_INITIAL_USER: admin
+  FS_INITIAL_PASS: admin
+  FS_CODPAIS: ESP
+  FS_COMPANY_NAME: "Empresa Demo S.L."
+  FS_COMPANY_CIF: "B12345678"
+  FS_COMPANY_REGIMENIVA: General
+```
+
+With this configuration, on first startup the container will:
+1. Create the admin user and set the homepage to Dashboard
+2. Configure the company with the given name, CIF, and country
+3. Initialize all FacturaScripts models (creates all database tables)
+4. Load the default accounting plan for the selected country
+5. Set country-specific defaults (tax rates, document series, etc.)
+
+### 5. Seed Data Loading
+
+You can pre-populate your FacturaScripts instance with suppliers, products, customers, or any model data using a JSON seed file. This is useful for development, testing, demos, and playground environments.
+
+#### How to Use
+
+Set the `FS_SEED_FILE` environment variable to point to a JSON file inside the container:
+
+```yaml
+environment:
+  FS_SEED_FILE: /var/www/html/Plugins/MyPlugin/seed.json
+```
+
+#### JSON Format
+
+The seed file must have a `seed` key containing model data. You can use either **model names** (exact FacturaScripts class names) or **convenience aliases**:
+
+| Alias        | Model Name |
+|--------------|------------|
+| `suppliers`  | `Proveedor` |
+| `products`   | `Producto`  |
+| `customers`  | `Cliente`   |
+
+```json
+{
+  "seed": {
+    "suppliers": [
+      {
+        "nombre": "Telefónica S.A.",
+        "cifnif": "A28015865",
+        "tipoidfiscal": "CIF",
+        "regimeniva": "General",
+        "_unique": "cifnif"
+      }
+    ],
+    "products": [
+      {
+        "referencia": "SERV-HOSTING",
+        "descripcion": "Web hosting service",
+        "precio": 9.99,
+        "_unique": "referencia"
+      }
+    ]
+  }
+}
+```
+
+#### Duplicate Detection
+
+Each record can include a `_unique` field that specifies which field to use for duplicate checking. If a record with the same value already exists, it is skipped. If `_unique` is not specified, the first non-empty string field is used.
+
+#### Using Model Names Directly
+
+You can also use FacturaScripts model class names directly as keys:
+
+```json
+{
+  "seed": {
+    "Proveedor": [
+      {"nombre": "Acme Corp", "cifnif": "X1234567X", "_unique": "cifnif"}
+    ],
+    "FormaPago": [
+      {"descripcion": "Wire Transfer", "codpago": "WIRE", "_unique": "codpago"}
+    ]
+  }
+}
+```
+
+Any valid FacturaScripts Dinamic model can be used as a key.
+
+#### Example docker-compose.yml
+
+```yaml
+services:
+  facturascripts:
+    image: erseco/alpine-facturascripts
+    environment:
+      FS_INITIAL_USER: admin
+      FS_INITIAL_PASS: admin
+      FS_COMPANY_NAME: "Demo Company"
+      FS_SEED_FILE: /data/seed.json
+    volumes:
+      - ./seed.json:/data/seed.json:ro
+```
+
+### 6. Scheduled Tasks (Cron)
 
 FacturaScripts requires a cron process for certain tasks in some plugins. While not strictly mandatory, **it is highly recommended** to run scheduled tasks.
 
@@ -433,7 +559,7 @@ View cron logs:
 docker compose logs facturascripts | grep cron
 ```
 
-### 5. Manual Plugin Installation
+### 7. Manual Plugin Installation
 
 FacturaScripts plugins can also be installed manually through the web interface:
 

--- a/rootfs/docker-entrypoint-init.d/02-configure-facturascripts.sh
+++ b/rootfs/docker-entrypoint-init.d/02-configure-facturascripts.sh
@@ -311,6 +311,20 @@ install_plugins
 # Rebuild FacturaScripts after initial configuration
 rebuild_facturascripts
 
+# Complete Wizard setup if FS_INITIAL_USER is set
+if [ -n "${FS_INITIAL_USER:-}" ] && [ -f "/var/www/html/config.php" ]; then
+    echo "=== Running FacturaScripts Setup ==="
+    php84 /usr/local/bin/setup-facturascripts.php
+    echo "=== Setup Completed ==="
+fi
+
+# Load seed data if FS_SEED_FILE is set
+if [ -n "${FS_SEED_FILE:-}" ] && [ -f "${FS_SEED_FILE}" ]; then
+    echo "=== Loading Seed Data ==="
+    php84 /usr/local/bin/seed-facturascripts.php "${FS_SEED_FILE}"
+    echo "=== Seed Data Completed ==="
+fi
+
 # Execute post-configure commands if the variable is set
 if [ -n "${POST_CONFIGURE_COMMANDS:-}" ]; then
     echo "Executing post-configure commands..."

--- a/rootfs/usr/local/bin/seed-facturascripts.php
+++ b/rootfs/usr/local/bin/seed-facturascripts.php
@@ -1,0 +1,161 @@
+#!/usr/bin/php84
+<?php
+
+/**
+ * FacturaScripts Seed Data Loader.
+ *
+ * Loads seed data from a JSON file into FacturaScripts using Dinamic models.
+ * Equivalent to alpine-omeka-s's import_cli.php.
+ *
+ * JSON format:
+ *   {
+ *     "seed": {
+ *       "Proveedor": [
+ *         {"nombre": "Acme", "cifnif": "B12345678", "_unique": "cifnif"}
+ *       ],
+ *       "Producto": [
+ *         {"referencia": "PROD-1", "descripcion": "Widget", "_unique": "referencia"}
+ *       ]
+ *     }
+ *   }
+ *
+ * Each key under "seed" must be a valid FacturaScripts model name.
+ * The optional "_unique" field specifies which field to use for duplicate checking.
+ * If "_unique" is not set, the first field in the record is used.
+ *
+ * Also supports the AiScan blueprint format:
+ *   {
+ *     "seed": {
+ *       "suppliers": [...],   -> maps to Proveedor
+ *       "products": [...]     -> maps to Producto
+ *     }
+ *   }
+ *
+ * Environment variables:
+ *   FS_SEED_FILE    Path to the JSON seed file
+ *
+ * Usage: php84 seed-facturascripts.php <path-to-json>
+ *        php84 seed-facturascripts.php (reads FS_SEED_FILE env var)
+ */
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+define('FS_FOLDER', '/var/www/html');
+
+$configFile = FS_FOLDER . '/config.php';
+if (!file_exists($configFile)) {
+    echo "[seed] config.php not found. Skipping.\n";
+    exit(0);
+}
+
+require_once FS_FOLDER . '/vendor/autoload.php';
+require_once $configFile;
+
+use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Kernel;
+use FacturaScripts\Core\Plugins;
+use FacturaScripts\Core\Where;
+
+Kernel::init();
+Plugins::deploy(true, true);
+
+$db = new DataBase();
+if (!$db->connect()) {
+    fwrite(STDERR, "[seed] Cannot connect to database.\n");
+    exit(1);
+}
+
+// Resolve seed file path
+$seedFile = $argv[1] ?? getenv('FS_SEED_FILE') ?: '';
+if (empty($seedFile) || !file_exists($seedFile)) {
+    echo "[seed] No seed file found. Skipping.\n";
+    exit(0);
+}
+
+$data = json_decode(file_get_contents($seedFile), true);
+if (!is_array($data) || empty($data['seed'])) {
+    echo "[seed] No 'seed' key in JSON file. Skipping.\n";
+    exit(0);
+}
+
+echo "[seed] Loading seed data from: {$seedFile}\n";
+
+// Alias mapping for convenience keys
+$aliases = [
+    'suppliers' => 'Proveedor',
+    'products' => 'Producto',
+    'customers' => 'Cliente',
+];
+
+$seed = $data['seed'];
+$totalCreated = 0;
+$totalSkipped = 0;
+
+foreach ($seed as $key => $records) {
+    if (!is_array($records) || empty($records)) {
+        continue;
+    }
+
+    // Resolve model name from alias or direct name
+    $modelName = $aliases[$key] ?? $key;
+    $className = '\\FacturaScripts\\Dinamic\\Model\\' . $modelName;
+
+    if (!class_exists($className)) {
+        echo "[seed] Model not found: {$modelName}. Skipping.\n";
+        continue;
+    }
+
+    echo "[seed] Loading {$modelName} (" . count($records) . " records)...\n";
+
+    foreach ($records as $record) {
+        if (!is_array($record)) {
+            continue;
+        }
+
+        // Determine unique field for duplicate check
+        $uniqueField = $record['_unique'] ?? null;
+        unset($record['_unique']);
+
+        if ($uniqueField === null) {
+            // Auto-detect: use first non-empty string field
+            foreach ($record as $field => $value) {
+                if (is_string($value) && !empty($value)) {
+                    $uniqueField = $field;
+                    break;
+                }
+            }
+        }
+
+        // Check for duplicates
+        if ($uniqueField && isset($record[$uniqueField])) {
+            $model = new $className();
+            $where = [Where::eq($uniqueField, $record[$uniqueField])];
+            if ($model->loadWhere($where)) {
+                $label = $record[$uniqueField];
+                echo "  Exists: {$label}\n";
+                $totalSkipped++;
+                continue;
+            }
+        }
+
+        // Create the record
+        $model = new $className();
+        foreach ($record as $field => $value) {
+            if (property_exists($model, $field)) {
+                $model->$field = $value;
+            }
+        }
+
+        $label = $record[$uniqueField ?? array_key_first($record)] ?? '?';
+        if ($model->save()) {
+            echo "  Created: {$label}\n";
+            $totalCreated++;
+        } else {
+            echo "  FAILED: {$label}\n";
+        }
+    }
+}
+
+echo "[seed] Done: {$totalCreated} created, {$totalSkipped} skipped.\n";

--- a/rootfs/usr/local/bin/setup-facturascripts.php
+++ b/rootfs/usr/local/bin/setup-facturascripts.php
@@ -1,0 +1,146 @@
+#!/usr/bin/php84
+<?php
+
+/**
+ * FacturaScripts Wizard Auto-Setup Script.
+ *
+ * Completes the FacturaScripts installation wizard programmatically,
+ * replacing the need for manual browser-based setup. Equivalent to
+ * alpine-omeka-s's install_cli.php.
+ *
+ * Environment variables:
+ *   FS_CODPAIS              Country code (default: ESP)
+ *   FS_COMPANY_NAME         Company name (default: Mi Empresa)
+ *   FS_COMPANY_CIF          Company tax ID (default: empty)
+ *   FS_COMPANY_REGIMENIVA   VAT regime (default: General)
+ *   FS_LOAD_ACCOUNTING_PLAN Load default accounting plan (default: true)
+ *
+ * Usage: php84 setup-facturascripts.php
+ */
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+define('FS_FOLDER', '/var/www/html');
+
+$configFile = FS_FOLDER . '/config.php';
+if (!file_exists($configFile)) {
+    echo "[setup] config.php not found. Skipping.\n";
+    exit(0);
+}
+
+require_once FS_FOLDER . '/vendor/autoload.php';
+require_once $configFile;
+
+use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Kernel;
+use FacturaScripts\Core\Plugins;
+use FacturaScripts\Core\Tools;
+
+Kernel::init();
+Plugins::deploy(true, true);
+
+$db = new DataBase();
+if (!$db->connect()) {
+    fwrite(STDERR, "[setup] Cannot connect to database.\n");
+    exit(1);
+}
+
+// Check if Wizard already completed (admin homepage != Wizard)
+$users = $db->select("SELECT homepage FROM users WHERE nick = 'admin'");
+if (!empty($users) && ($users[0]['homepage'] ?? 'Wizard') !== 'Wizard') {
+    echo "[setup] FacturaScripts already set up. Skipping.\n";
+    exit(0);
+}
+
+echo "[setup] Completing FacturaScripts Wizard...\n";
+
+// Step 1: Initialize core models (Wizard Step 1)
+$coreModels = [
+    'AttachedFile', 'Diario', 'EstadoDocumento', 'FormaPago',
+    'Impuesto', 'Retencion', 'Serie', 'Provincia',
+];
+foreach ($coreModels as $name) {
+    $cls = '\\FacturaScripts\\Dinamic\\Model\\' . $name;
+    if (class_exists($cls)) {
+        new $cls();
+    }
+}
+
+// Step 2: Set country defaults
+$codpais = getenv('FS_CODPAIS') ?: 'ESP';
+$filePath = FS_FOLDER . '/Dinamic/Data/Codpais/' . $codpais . '/default.json';
+if (file_exists($filePath)) {
+    $defaults = json_decode(file_get_contents($filePath), true) ?? [];
+    foreach ($defaults as $group => $values) {
+        foreach ($values as $key => $value) {
+            Tools::settingsSet($group, $key, $value);
+        }
+    }
+}
+Tools::settingsSet('default', 'codpais', $codpais);
+Tools::settingsSet('default', 'homepage', 'Dashboard');
+Tools::settingsSave();
+echo "[setup] Country defaults set: {$codpais}\n";
+
+// Step 3: Configure company
+$empresa = new \FacturaScripts\Dinamic\Model\Empresa();
+if ($empresa->loadFromCode(1)) {
+    $empresa->nombre = getenv('FS_COMPANY_NAME') ?: 'Mi Empresa';
+    $empresa->nombrecorto = $empresa->nombre;
+    $empresa->cifnif = getenv('FS_COMPANY_CIF') ?: '';
+    $empresa->codpais = $codpais;
+    $empresa->regimeniva = getenv('FS_COMPANY_REGIMENIVA') ?: 'General';
+    $empresa->save();
+    echo "[setup] Company: {$empresa->nombre}\n";
+}
+
+// Step 4: Update warehouse country
+$almacen = new \FacturaScripts\Dinamic\Model\Almacen();
+foreach ($almacen->all() as $alm) {
+    $alm->codpais = $codpais;
+    $alm->save();
+}
+
+// Step 5: Initialize ALL Dinamic models (Wizard Step 3 — creates all tables)
+$dinamicModelDir = FS_FOLDER . '/Dinamic/Model';
+if (is_dir($dinamicModelDir)) {
+    foreach (scandir($dinamicModelDir) as $file) {
+        if (substr($file, -4) === '.php') {
+            $cls = '\\FacturaScripts\\Dinamic\\Model\\' . substr($file, 0, -4);
+            if (class_exists($cls)) {
+                try {
+                    new $cls();
+                } catch (\Throwable $e) {
+                    // Skip models that fail to instantiate
+                }
+            }
+        }
+    }
+}
+
+// Step 6: Re-deploy to register routes for all models
+Plugins::deploy(true, true);
+
+// Step 7: Set admin homepage to Dashboard
+$db->exec("UPDATE users SET homepage = 'Dashboard' WHERE nick = 'admin'");
+echo "[setup] Admin homepage set to Dashboard.\n";
+
+// Step 8: Load default accounting plan
+$loadPlan = getenv('FS_LOAD_ACCOUNTING_PLAN');
+if ($loadPlan === false || $loadPlan === '' || $loadPlan === 'true' || $loadPlan === '1') {
+    $planFile = FS_FOLDER . '/Dinamic/Data/Codpais/' . $codpais . '/defaultPlan.csv';
+    if (file_exists($planFile)) {
+        $ejercicios = $db->select('SELECT codejercicio FROM ejercicios LIMIT 1');
+        if (!empty($ejercicios)) {
+            $cls = '\\FacturaScripts\\Dinamic\\Lib\\Accounting\\AccountingPlanImport';
+            if (class_exists($cls)) {
+                (new $cls())->importCSV($planFile, $ejercicios[0]['codejercicio']);
+                echo "[setup] Accounting plan loaded.\n";
+            }
+        }
+    }
+}
+
+echo "[setup] FacturaScripts setup completed.\n";


### PR DESCRIPTION
## Summary

- Add `setup-facturascripts.php` CLI script that completes the FacturaScripts installation Wizard programmatically — configures company, initializes all models/tables, loads accounting plan, and sets admin homepage to Dashboard
- Add `seed-facturascripts.php` CLI script that loads suppliers, products, and any FacturaScripts model data from a JSON seed file
- Integrate both scripts into the Docker entrypoint (`02-configure-facturascripts.sh`) with new env vars
- Document new features and env vars in README

## New Environment Variables

| Variable | Description | Default |
|----------|-------------|---------|
| `FS_CODPAIS` | Country code (ESP, DEU, FRA...) | `ESP` |
| `FS_COMPANY_NAME` | Company name | `Mi Empresa` |
| `FS_COMPANY_CIF` | Company tax ID | `""` |
| `FS_COMPANY_REGIMENIVA` | VAT regime | `General` |
| `FS_LOAD_ACCOUNTING_PLAN` | Load default accounting plan | `true` |
| `FS_SEED_FILE` | Path to JSON seed data file | `""` |

## Motivation

Every FacturaScripts plugin that needs Docker dev/test setup currently has to reinvent Wizard bypass and seed loading via `POST_CONFIGURE_COMMANDS`. This moves reusable logic into the base container, paralleling `alpine-omeka-s`'s `install_cli.php` + `import_cli.php` pattern.

## Test plan

- [ ] `docker compose up` with `FS_INITIAL_USER` set — should skip Wizard and go straight to Dashboard
- [ ] Set `FS_COMPANY_NAME`/`FS_COMPANY_CIF` — verify company is configured correctly
- [ ] Set `FS_SEED_FILE` pointing to a JSON with suppliers/products — verify data appears in FS
- [ ] Without `FS_INITIAL_USER` — Wizard should still appear (no regression)
- [ ] Second startup with same volume — setup and seed should be idempotent (no duplicates)